### PR TITLE
Included iostream to fix building on OSX

### DIFF
--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -124,15 +124,6 @@ class cli
 		auto old_data = parse_data(opt.datadir+"/old", complete_parser::parse);
 		auto new_data = parse_data(opt.datadir+"/new", complete_parser::parse);
 
-		new_data.erase(std::remove_if(
-			new_data.begin(),
-			new_data.end(),
-			[&](const evaluation& x) -> bool
-			{
-				return x.course_grade.count() == 0;
-			}
-		), new_data.end());
-
 		std::sort(
 			new_data.begin(),
 			new_data.end(),

--- a/src/complete_parser.hpp
+++ b/src/complete_parser.hpp
@@ -33,7 +33,8 @@ namespace vakkenranking
 			const static std::vector<std::string> keys = {
 				"[Ik geef deze cursus het volgende rapportcijfer] Ik geef deze cursus het volgende rapportcijfer",
 				"Ik geef deze cursus het volgende rapportcijfer [Ik geef deze cursus het volgende rapportcijfer]",
-				"[I would rate this course] On a scale from 1 to 10 (10 being excellent) I would rate this course"
+				"[I would rate this course] On a scale from 1 to 10 (10 being excellent) I would rate this course",
+				"On a scale from 1 to 10 (10 being excellent) I would rate this course [I would rate this course]"
 			};
 			
 			return find_key(line, keys, path, "course_grade");
@@ -44,7 +45,8 @@ namespace vakkenranking
 			const static std::vector<std::string> keys = {
 				"[Ik geef de docent(en) het volgende rapportcijfer] Ik geef de docent(en) het volgende rapportcijfer",
 				"Ik geef de docent(en) het volgende rapportcijfer [Ik geef de docent(en) het volgende rapportcijfer]",
-				"[I would rate the lecturer(s)/teacher(s)] On a scale from 1 to 10 (10 being excellent) I would rate the lecturer(s)/teacher(s)"
+				"[I would rate the lecturer(s)/teacher(s)] On a scale from 1 to 10 (10 being excellent) I would rate the lecturer(s)/teacher(s)",
+				"On a scale from 1 to 10 (10 being excellent) I would rate the lecturer(s)/teacher(s) [I would rate the lecturer(s)/teacher(s)]"
 			};
 			
 			return find_key(line, keys, path, "teacher_grade");

--- a/src/csv_parser.cpp
+++ b/src/csv_parser.cpp
@@ -1,5 +1,6 @@
 #include "csv_parser.hpp"
 
+#include <iostream>
 #include <stdexcept>
 #include <boost/tokenizer.hpp>
 

--- a/src/printer.hpp
+++ b/src/printer.hpp
@@ -86,7 +86,7 @@ namespace vakkenranking
 			std::cout << "<!DOCTYPE html><html>\n<head>\n"
 				<< "\t<meta charset=\"UTF-8\" />\n"
 				<< "\t<title>OLC III - Vakkenranking 2013-2014</title>\n"
-				<< "\t<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\"http://olciii.nl/wp-content/themes/twentyeleven/style.css\">\n"
+				<< "\t<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\"http://olc.cs.ru.nl/assets/twentyeleven.css\">\n"
 				<< "\t<style>\n"
 				<< "\t\t.entry-content {\n"
 				<< "\t\t\tpadding: 0;\n"
@@ -250,6 +250,7 @@ namespace vakkenranking
 				<< "<tr><td class=\"legend-left\"><span style=\"color: red\">▼ kleur</span></td><td>&rarr;</td><td>significant aantal deelnemers</td></tr>\n"
 				<< "<tr><td class=\"legend-left\">!</td><td>&rarr;</td><td>cursus nieuw in 2013-2014</td></tr>\n"
 				<< "<tr><td class=\"legend-left\">?</td><td>&rarr;</td><td>geen enquêteresultaten uit 2012-2013</td></tr>\n"
+				<< "</table></div>"
 				<< "</body></html>";
 		}
 	};


### PR DESCRIPTION
Building on OSX would result in:

```
src/csv_parser.cpp:48:9: error: 
      no member named 'cerr' in namespace 'std'
```

but this can be resolved by including the iostream headers.

Additionally, this pull request now includes the new phrase as used in the csv files, as well as minor output fixes.
